### PR TITLE
[WIP] Upgrade dependency to AWS v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.0
+
+- [BC] SlmQueueSqs is now based on AWS SDK v3. As a consequence, minimum PHP dependency has been bumped to 5.5.
+
 # 0.4.2
 
 - SlmQueueSqs now rethrow SQS exceptions instead of silently reinserting the job without notice.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SlmQueueSqs
 [![Latest Unstable Version](https://poser.pugx.org/slm/queue-sqs/v/unstable.png)](https://packagist.org/packages/slm/queue-sqs)
 [![Total Downloads](https://poser.pugx.org/slm/queue-sqs/downloads.png)](https://packagist.org/packages/slm/queue-sqs)
 
-Version 0.4.0 Created by Jurian Sluiman and Michaël Gallego
+Version 0.5.0 Created by Jurian Sluiman and Michaël Gallego
 
 Requirements
 ------------
@@ -35,11 +35,11 @@ add the following line into your `composer.json` file:
 
 ```json
 "require": {
-	"slm/queue-sqs": "0.4.*"
+	"slm/queue-sqs": "0.5.*"
 }
 ```
 
-Then, enable the module by adding `SlmQueueSqs` in your application.config.php file (you must also add the `Aws` key
+Then, enable the module by adding `SlmQueueSqs` in your application.config.php file (you must also add the `AwsModule` key
 for enabling the AWS ZF2 module.
 
 > Starting from 0.3.0, SlmQueueSqs now internally uses the official AWS Zend Framework 2 module, so you can write

--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,12 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5",
         "zendframework/zend-mvc": "~2.2",
         "zendframework/zend-servicemanager": "~2.2",
         "zendframework/zend-stdlib": "~2.2",
         "slm/queue": "0.4.*",
-        "aws/aws-sdk-php": ">=2.1.1",
-        "aws/aws-sdk-php-zf2": "1.*"
+        "aws/aws-sdk-php-zf2": "2.*"
     },
     "require-dev": {
         "zendframework/zendframework": "~2.2",

--- a/src/SlmQueueSqs/Factory/SqsQueueFactory.php
+++ b/src/SlmQueueSqs/Factory/SqsQueueFactory.php
@@ -2,6 +2,8 @@
 
 namespace SlmQueueSqs\Factory;
 
+use Aws\Sdk as Aws;
+use SlmQueue\Job\JobPluginManager;
 use SlmQueueSqs\Options\SqsQueueOptions;
 use SlmQueueSqs\Queue\SqsQueue;
 use Zend\ServiceManager\FactoryInterface;
@@ -18,8 +20,8 @@ class SqsQueueFactory implements FactoryInterface
     public function createService(ServiceLocatorInterface $serviceLocator, $name = '', $requestedName = '')
     {
         $parentLocator    = $serviceLocator->getServiceLocator();
-        $sqsClient        = $parentLocator->get('Aws')->get('Sqs');
-        $jobPluginManager = $parentLocator->get('SlmQueue\Job\JobPluginManager');
+        $sqsClient        = $parentLocator->get(Aws::class)->create('Sqs');
+        $jobPluginManager = $parentLocator->get(JobPluginManager::class);
 
         // Let's see if we have options for this specific queue
         $config  = $parentLocator->get('Config');

--- a/src/SlmQueueSqs/Factory/SqsWorkerControllerFactory.php
+++ b/src/SlmQueueSqs/Factory/SqsWorkerControllerFactory.php
@@ -2,7 +2,9 @@
 
 namespace SlmQueueSqs\Factory;
 
+use SlmQueue\Queue\QueuePluginManager;
 use SlmQueueSqs\Controller\SqsWorkerController;
+use SlmQueueSqs\Worker\SqsWorker;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -18,8 +20,8 @@ class SqsWorkerControllerFactory implements FactoryInterface
     {
         $parentLocator = $serviceLocator->getServiceLocator();
 
-        $worker  = $parentLocator->get('SlmQueueSqs\Worker\SqsWorker');
-        $manager = $parentLocator->get('SlmQueue\Queue\QueuePluginManager');
+        $worker  = $parentLocator->get(SqsWorker::class);
+        $manager = $parentLocator->get(QueuePluginManager::class);
 
         return new SqsWorkerController($worker, $manager);
     }

--- a/tests/TestConfiguration.php.dist
+++ b/tests/TestConfiguration.php.dist
@@ -18,7 +18,7 @@
  */
 return array(
     'modules' => array(
-        'Aws',
+        'AwsModule',
         'SlmQueue',
         'SlmQueueSqs'
     ),

--- a/tests/testing.config.php
+++ b/tests/testing.config.php
@@ -18,9 +18,11 @@
  */
 return array(
     'aws' => array(
-        'region' => 'eu-west-1',
-        'key'    => 'my-key',
-        'secret' => 'my-secret'
+        'credentials' => array(
+            'key'    => 'my-key',
+            'secret' => 'my-secret'
+        ),
+        'region' => 'eu-west-1'
     ),
 
     'slm_queue' => array(


### PR DESCRIPTION
Hi,

ping @basz @juriansluiman 

This PR upgrades the module to the new AWS SDK v3, which brings many advantages (more performance, PSR7 support, and above all because all new features in AWS are only supported in the new SDK...).

As a conseuqence this brings dependency to PHP 5.5

I'd like to bump all other SlmQueue module to PHP 5.5 too before merging this PR.