### PR TITLE
Resolves issue w/ not being able to  update composer deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "zendframework/zend-servicemanager": "^2.7 || ^3.0",
         "zendframework/zend-stdlib": "^2.2 || ^3.0",
         "slm/queue": "^0.6",
-        "aws/aws-sdk-php-zf2": "^2.0,>=2.0.2"
+        "aws/aws-sdk-php-zf2": "^3.0"
     },
     "require-dev": {
         "zendframework/zend-config": "^2.2",


### PR DESCRIPTION
looks like upstream aws-sdk-php-zf2 broke the ^2.0 release.