### PR TITLE
Update AWS Module Dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "zendframework/zend-servicemanager": "^2.7 || ^3.0",
         "zendframework/zend-stdlib": "^2.2 || ^3.0",
         "slm/queue": "^1.0",
-        "aws/aws-sdk-php-zf2": "^3.0"
+        "aws/aws-sdk-php-zf2": "^3.0 || ^4.0"
     },
     "require-dev": {
         "zendframework/zend-config": "^2.2",


### PR DESCRIPTION
This will allows the module to work with ZF3 version of the AWS module.